### PR TITLE
Adds tk-multi-setcontext functionality.

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,21 +16,25 @@ class MultiWorkFiles(tank.platform.Application):
         """
         Called as the application is being initialized
         """
-        
+
         tk_multi_workfiles = self.import_module("tk_multi_workfiles")
 
         # register commands:
         self._work_files_handler = tk_multi_workfiles.WorkFiles(self)
         self.engine.register_command("Tank File Manager...", self._work_files_handler.show_dlg)
+        self.engine.register_command("Switch Context...", self.switch_context, {"type": "context_menu"})
 
         # other commands are only valid if we have valid work and publish templates:
         if self.get_template("template_work") and self.get_template("template_publish"):
             cmd = lambda app=self: tk_multi_workfiles.SaveAs.show_save_as_dlg(app)
             self.engine.register_command("Tank Save As...", cmd)
-            
+
             cmd = lambda app=self: tk_multi_workfiles.Versioning.show_change_version_dlg(app)
             self.engine.register_command("Version up Current Scene...", cmd)
-        
+
+    def switch_context(self):
+        self._work_files_handler.change_work_area(do_switch_context=True)
+
     def destroy_app(self):
         self.log_debug("Destroying tk-multi-workfiles")
         self._work_files_handler = None

--- a/hooks/scene_operation_tk-nuke.py
+++ b/hooks/scene_operation_tk-nuke.py
@@ -13,69 +13,69 @@ from tank.platform.qt import QtGui
 
 class SceneOperation(Hook):
     """
-    Hook called to perform an operation with the 
+    Hook called to perform an operation with the
     current scene
     """
-    
+
     def execute(self, operation, file_path, context, **kwargs):
         """
         Main hook entry point
-        
+
         :operation: String
                     Scene operation to perform
-        
+
         :file_path: String
                     File path to use if the operation
                     requires it (e.g. open)
-                    
+
         :context:   Context
                     The context the file operation is being
                     performed in.
-                    
+
         :returns:   Depends on operation:
                     'current_path' - Return the current scene
                                      file path as a String
-                    'reset'        - True if scene was reset to an empty 
+                    'reset'        - True if scene was reset to an empty
                                      state, otherwise False
                     all others     - None
         """
-        
+
         if file_path:
             file_path = file_path.replace("/", os.path.sep)
-        
+
         if operation == "current_path":
             # return the current script path
             return nuke.root().name().replace("/", os.path.sep)
-        
+
         elif operation == "open":
             # open the specified script
             nuke.scriptOpen(file_path)
-            
+
             # reset any write node render paths:
             if self._reset_write_node_render_paths():
                 # something changed so make sure to save the script again:
                 nuke.scriptSave()
-            
+
         elif operation == "save":
             # save the current script:
             nuke.scriptSave()
-            
+
         elif operation == "save_as":
             old_path = nuke.root()["name"].value()
             try:
                 # rename script:
                 nuke.root()["name"].setValue(file_path)
-                        
+
                 # reset all write nodes:
                 self._reset_write_node_render_paths()
-                    
+
                 # save script:
-                nuke.scriptSaveAs(file_path, -1)    
+                nuke.scriptSaveAs(file_path, -1)
             except Exception, e:
                 # something went wrong so reset to old path:
                 nuke.root()["name"].setValue(old_path)
                 raise TankError("Failed to save scene %s", e)
-            
+
         elif operation == "reset":
             """
             Reset the scene to an empty state
@@ -86,22 +86,35 @@ class SceneOperation(Hook):
                                                  "Save your script?",
                                                  "Your script has unsaved changes. Save before proceeding?",
                                                  QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
-            
+
                 if res == QtGui.QMessageBox.Cancel:
                     return False
                 elif res == QtGui.QMessageBox.No:
                     break
                 else:
-                    nuke.scriptSave()
+                    scene_name = nuke.root().name()
+                    engine = tank.platform.current_engine()
+                    if scene_name == "Root":
+                        tank_save = engine.commands.get("Tank Save As...")
+                        try:
+                            tank_save.get("callback")()
+                        except:
+                            nuke.scriptSave()
+                    else:
+                        snapshot = engine.commands.get("Snapshot...")
+                        try:
+                            snapshot.get("callback")()
+                        except:
+                            nuke.scriptSave()
 
             # now clear the script:
             nuke.scriptClear()
-            
+
             return True
         else:
             raise TankError("Don't know how to perform scene operation '%s'" % operation)
-        
-        
+
+
     def _reset_write_node_render_paths(self):
         """
         Use the tk-nuke-writenode app interface to find and reset
@@ -110,11 +123,11 @@ class SceneOperation(Hook):
         write_node_app = self.parent.engine.apps.get("tk-nuke-writenode")
         if not write_node_app:
             return
-        
+
         write_nodes = write_node_app.get_write_nodes()
         for write_node in write_nodes:
             write_node_app.reset_node_render_path(write_node)
-            
+
         return len(write_nodes) > 0
-        
-        
+
+

--- a/hooks/scene_operation_tk-softimage.py
+++ b/hooks/scene_operation_tk-softimage.py
@@ -18,29 +18,29 @@ Application = Dispatch("XSI.Application").Application
 
 class SceneOperation(Hook):
     """
-    Hook called to perform an operation with the 
+    Hook called to perform an operation with the
     current scene
     """
-    
+
     def execute(self, operation, file_path, **kwargs):
         """
         Main hook entry point
-        
+
         :operation: String
                     Scene operation to perform
-        
+
         :file_path: String
                     File path to use if the operation
                     requires it (e.g. open)
-                    
+
         :returns:   Depends on operation:
                     'current_path' - Return the current scene
                                      file path as a String
-                    'reset'        - True if scene was reset to an empty 
+                    'reset'        - True if scene was reset to an empty
                                      state, otherwise False
                     all others     - None
         """
-        
+
         if operation == "current_path":
             # return the current scene path
             scene_name = Application.ActiveProject.ActiveScene.Name
@@ -65,6 +65,23 @@ class SceneOperation(Hook):
 
         elif operation == "reset":
             # reset the scene to an empty state
+
+            # NEED TO IMPLEMENT
+            # scene_name = nuke.root().name()
+            # engine = tank.platform.current_engine()
+            # if scene_name == "Root":
+            #     tank_save = engine.commands.get("Tank Save As...")
+            #     try:
+            #         tank_save.get("callback")()
+            #     except:
+            #         Application.SaveSceneAs(file_path, 0)
+            # else:
+            #     snapshot = engine.commands.get("Snapshot...")
+            #     try:
+            #         snapshot.get("callback")()
+            #     except:
+                    # xsi save scene.
+
             try:
                 # use the standard Softimage mechanism to check
                 # for and save the file if required:

--- a/info.yml
+++ b/info.yml
@@ -25,13 +25,13 @@ configuration:
         optional_fields: [name]
         description: A reference to a template which locates a publish file on disk.
         allows_empty: True
-           
+
     template_publish_area:
         type: template
         description: A reference to a template which locates the publish directory on
                      disk
         allows_empty: True
-           
+
     sg_entity_types:
         type: list
         description: "List of Shotgun Entity Types to include in the listings when
@@ -39,41 +39,51 @@ configuration:
         default_value: [Shot, Asset]
         values:
             type: shotgun_entity_type
-           
+
+    allow_task_creation:
+        type: bool
+        description: "Controls whether new tasks can be created from the app."
+        default_value: True
+
+    launch_at_startup:
+        type: bool
+        description: A flag whether to launch this app's UI at startup.
+        default_value: false
+
     hook_scene_operation:
         type: hook
         parameters: [operation, file_path]
         default_value: "scene_operation_{engine_name}"
-        description: All the application specific scene operations (open, save etc) that 
+        description: All the application specific scene operations (open, save etc) that
                      the app needs to carry out are collected together in this hook.
-        
+
     hook_copy_file:
         type: hook
         parameters: [source_path, target_path]
         default_value: copy_file
-        description: Specify a hook that will be used to copy the file 'source_path' 
+        description: Specify a hook that will be used to copy the file 'source_path'
                      to 'target_path'.
-           
-            
+
+
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:
 
-# More verbose description of this item 
+# More verbose description of this item
 display_name: "Manage your Work Files"
-description: "Using this app you can change the current work area and 
-              browse work files and publishes.  The app additionally 
-              provides 'Save As' and 'Change Version' commands for 
+description: "Using this app you can change the current work area and
+              browse work files and publishes.  The app additionally
+              provides 'Save As' and 'Change Version' commands for
               managing work files"
-              
+
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.13.22"
-requires_engine_version: 
+requires_engine_version:
 
 # the engines that this app can operate in:
-supported_engines: 
+supported_engines:
 
 # the frameworks required to run this app
 frameworks:
     - {"name": "tk-framework-widget", "version": "v0.1.13"}
-    
+

--- a/python/tk_multi_workfiles/new_task.py
+++ b/python/tk_multi_workfiles/new_task.py
@@ -1,0 +1,84 @@
+"""
+Copyright (c) 2012 Shotgun Software, Inc
+----------------------------------------------------
+"""
+import tank
+import os
+import sys
+import threading
+
+from tank.platform.qt import QtCore, QtGui
+from .ui.new_task import Ui_NewTask
+
+class NewTaskDialog(QtGui.QDialog):
+
+    
+    def __init__(self, app, entity, parent):
+        QtGui.QDialog.__init__(self, parent)
+        self._app = app
+        # set up the UI
+        self.ui = Ui_NewTask() 
+        self.ui.setupUi(self)
+        
+        self._entity = entity
+        
+        # populate entity name
+        entity_name = "%s %s" % (self._entity["type"], self._entity["code"])
+        self.ui.entity.setText(entity_name)
+        
+        # populate user
+        self._curr_user = tank.util.get_shotgun_user(self._app.shotgun)
+        if self._curr_user is None:
+            username = "<unassigned>"
+        else:
+            username = self._curr_user["name"]
+        self.ui.assigned_to.setText(username)
+        
+        # populate pipeline steps
+        data = self._app.shotgun.find("Step", 
+                                      [["entity_type", "is", self._entity["type"]]],
+                                      ["code", "id"])
+        
+        self._pipeline_step_dict = {}
+        for x in data:
+            step_name = x.get("code")
+            if step_name is None:
+                step_name = "Unnamed Step"
+            self.ui.pipeline_step.addItem(step_name, step_name)
+            self._pipeline_step_dict[x.get("code", "")] = x.get("id")
+        
+        # try to figure out a default pipeline step and task name
+        if self._app.context.step:
+            step_name = self._app.context.step["name"]
+            idx = self.ui.pipeline_step.findData(step_name)
+            if idx != -1:
+                self.ui.pipeline_step.setCurrentIndex(idx)
+            self.ui.task_name.setText(step_name)
+        
+        
+    def create_task(self):
+        
+        # creates a new task. returns the task id or none on failure
+        
+        # get pipeline step id from the dropdown
+        pipeline_step_id = self._pipeline_step_dict[self.ui.pipeline_step.currentText()]
+        pipeline_step = {"type": "Step", "id": pipeline_step_id}
+        
+        data = {}
+        data["step"] = pipeline_step
+        data["project"] = self._app.context.project
+        data["entity"] = self._entity
+        data["content"] = self.ui.task_name.text()
+        if self._curr_user:
+            data["task_assignees"] = [self._curr_user]
+        
+        e = self._app.shotgun.create("Task", data) 
+        
+        # try to set it to IP
+        # not all studios use IP
+        try:
+            self._app.shotgun.update("Task", e["id"], {"sg_status_list": "ip"})
+        except:
+            pass
+        
+        return e["id"]

--- a/python/tk_multi_workfiles/select_work_area_form.py
+++ b/python/tk_multi_workfiles/select_work_area_form.py
@@ -10,35 +10,38 @@ import tank
 from tank.platform.qt import QtCore, QtGui
 
 from .task_browser import TaskBrowserWidget
+from .new_task import NewTaskDialog
 
 class SelectWorkAreaForm(QtGui.QWidget):
-    
+
     def __init__(self, app, handler, parent=None):
         """
         Construction
         """
         QtGui.QWidget.__init__(self, parent)
-        
+
         self._app = app
         self._handler = handler
-        
+
+        self.change_context_mode = False
+
         self._exit_code = QtGui.QDialog.Rejected
         self._settings = QtCore.QSettings("Shotgun Software", "tk-multi-workfiles")
 
         # set up the UI
         from .ui.select_work_area_form import Ui_SelectWorkAreaForm
-        self._ui = Ui_SelectWorkAreaForm() 
+        self._ui = Ui_SelectWorkAreaForm()
         self._ui.setupUi(self)
-        
+
         # set up the entity browser:
         self._ui.entity_browser.set_app(self._app)
         self._ui.entity_browser.selection_changed.connect(self._on_entity_selected)
-        
+
         types_to_load = self._app.get_setting("sg_entity_types", [])
         types_str = "Entities"
         if types_to_load:
             types_nice_names = [ tank.util.get_entity_type_display_name(self._app.tank, x) for x in types_to_load ]
-            
+
             plural_types = [ "%ss" % x for x in types_nice_names] # no fanciness (sheep, box, nucleus etc)
             if len(plural_types) == 1:
                 # "Shots"
@@ -48,48 +51,48 @@ class SelectWorkAreaForm(QtGui.QWidget):
                 types_str = ", ".join(plural_types[:-1])
                 types_str += " & %s" % plural_types[-1]
         self._ui.entity_browser.set_label(types_str)
-        
+
         # set up the task browser:
         self._ui.task_browser.set_app(self._app)
         self._ui.task_browser.selection_changed.connect(self._on_task_selected)
         self._ui.task_browser.action_requested.connect(self._on_context_selected)
         self._ui.task_browser.set_label("Tasks")
-        
+
         # connect the buttons:
         self._ui.select_btn.clicked.connect(self._on_context_selected)
         self._ui.cancel_btn.clicked.connect(self._on_cancel)
-        
+
         #TODO: implement task creation!
-        can_create_tasks = False#self._app.get_setting("allow_task_creation")        
+        can_create_tasks = self._app.get_setting("allow_task_creation")
         if can_create_tasks:
             self._ui.new_task_btn.clicked.connect( self._on_create_new_task )
         else:
             self._ui.new_task_btn.setVisible(False)
-        
+
         # set up the 'Only Show My Tasks' checkbox:
         self._ui.mine_only_cb.toggled.connect(self._on_mine_only_cb_toggled)
         try:
             # this qsettings stuff seems super flaky on different platforms
-            # - although setting is saved as an int, it can get loaded as either an 
+            # - although setting is saved as an int, it can get loaded as either an
             # int or a string, hence the double casting to int and then bool.
             show_mine_only = bool(int(self._settings.value("show_mine_only", True)))
             self._ui.mine_only_cb.setChecked(show_mine_only)
         except Exception, e:
             self._app.log_warning("Cannot restore state of 'Only Show My Tasks' checkbox: %s" % e)
-        
+
         # reload:
         ctx = self._handler.get_current_work_area()
         self._initial_task_to_select = ctx.task if ctx else None
         self._reload_entities(ctx.entity if ctx else None)
-        
+
     @property
     def exit_code(self):
         return self._exit_code
-        
+
     @property
     def context(self):
         return self._get_context()
-        
+
     def closeEvent(self, event):
         """
         Make sure that the various background threads are closed
@@ -98,30 +101,50 @@ class SelectWorkAreaForm(QtGui.QWidget):
         self._ui.task_browser.destroy()
         # okay to close!
         event.accept()
-    
+
     def _on_cancel(self):
         self._exit_code = QtGui.QDialog.Rejected
-        self.close()    
-        
-    def _on_context_selected(self):
-        self._exit_code = QtGui.QDialog.Accepted
         self.close()
-        
+
+    def _on_context_selected(self):
+        if self.change_context_mode:
+            self._do_change_context()
+        else:
+            self._exit_code = QtGui.QDialog.Accepted
+            self.close()
+
     def _on_create_new_task(self):
         """
-        Called when create task button is clicked
+        Called when new task button is clicked
         """
-        # run new task:
-        self._handler.create_new_task()
+        curr_selection = self._ui.entity_browser.selected_entity
+        if curr_selection is None:
+                QtGui.QMessageBox.warning(self,
+                                          "Please select an Entity!",
+                                          "Please select an Entity that you want to add a Task to.")
+                return
+
+        # do new task
+        new_task = NewTaskDialog(self._app, curr_selection, self)
+        # need to keep the reference alive otherwise the window is destroyed
+        if new_task.exec_() == QtGui.QDialog.Accepted:
+            # do it!
+            task_id = new_task.create_task()
+
+            # refresh - in case they cancel the context set, the dialog is up to date.
+            self._reload_tasks()
+
+            # and set the context to point here!
+            # self._on_context_selected()
 
     def _get_context(self):
         """
         Return a context for the current selection
         """
-        
+
         # get the selected task:
         task = self._ui.task_browser.selected_task
-        
+
         # try to create a context:
         ctx = None
         if task:
@@ -131,36 +154,36 @@ class SelectWorkAreaForm(QtGui.QWidget):
             entity = self._ui.entity_browser.selected_entity
             if entity:
                 ctx = self._app.tank.context_from_entity(entity.get("type"), entity.get("id"))
-                
+
         return ctx
-         
+
     def _on_mine_only_cb_toggled(self):
         """
         Called when mine-only checkbox is toggled
         """
         # remember setting - save value as an int as this
         # can be handled across all operating systems!
-        # - on Windows & Linux, boolean & int settings are 
+        # - on Windows & Linux, boolean & int settings are
         # returned as strings when queried!
         show_mine_only = self._ui.mine_only_cb.isChecked()
         self._settings.setValue("show_mine_only", int(show_mine_only))
-        
+
         # reload entity list:
         self._reload_entities()
-                
-        
+
+
     def _on_entity_selected(self):
         """
         Called when the selected entity is changed
         """
         self._reload_tasks()
-        
+
     def _on_task_selected(self):
         """
         Called when the selected task is changed
         """
         self._update_ui()
-        
+
     def _reload_entities(self, entity_to_select = None):
         """
         Called to reload the list of entities
@@ -168,24 +191,24 @@ class SelectWorkAreaForm(QtGui.QWidget):
         if not entity_to_select:
             entity_to_select = self._ui.entity_browser.selected_entity
             self._initial_task_to_select = None
-        
+
         # clear both entity and task lists:
         self._ui.entity_browser.clear()
         self._ui.task_browser.clear()
-        
+
         # reload entities:
         d = {}
         d["own_tasks_only"] = self._ui.mine_only_cb.isChecked()
         d["entity"] = entity_to_select
         self._ui.entity_browser.load(d)
-        
+
     def _reload_tasks(self):
         """
-        Called to reload the list of tasks based on the 
+        Called to reload the list of tasks based on the
         currently selected entity
         """
         self._ui.task_browser.clear()
-        
+
         curr_selection = self._ui.entity_browser.get_selected_item()
         if curr_selection is None:
             self._ui.task_browser.set_message("Please select an item in the listing to the left.")
@@ -195,18 +218,77 @@ class SelectWorkAreaForm(QtGui.QWidget):
         task_to_select = self._ui.task_browser.selected_task
         if not task_to_select:
             task_to_select = self._initial_task_to_select
-        
+
         # pass in data to task retreiver
         d = {}
         d["own_tasks_only"] = self._ui.mine_only_cb.isChecked()
         d["entity"] = curr_selection.sg_data
         d["task"] = task_to_select
-        
+
         # pass in the sg data dump for the entity to the task loader code
         self._ui.task_browser.load(d)
-        
+
         self._update_ui()
-        
+
+    def _do_change_context(self):
+        """
+        Set context based on selected task
+        """
+
+        if not self.context.task:
+            return
+
+        task_id = self.context.task.get("id")
+        try:
+            ctx = self._app.tank.context_from_entity("Task", task_id)
+        except Exception, e:
+            QtGui.QMessageBox.critical(self,
+                                       "Cannot Resolve Task!",
+                                       "Cannot resolve this task into a context: %s" % e)
+            return
+
+        message = QtGui.QMessageBox()
+        message.setIcon(QtGui.QMessageBox.Question)
+
+        yes_new_scene_button = message.addButton("Yes And New Scene", QtGui.QMessageBox.YesRole)
+
+        message.addButton(QtGui.QMessageBox.Yes)
+        message.addButton(QtGui.QMessageBox.No)
+        message.setDefaultButton(QtGui.QMessageBox.Yes)
+        message.setEscapeButton(QtGui.QMessageBox.No)
+        message.setWindowTitle("Change Context?")
+        message.setText("This will switch your work area to the "
+                      "selected Task. Are you sure you want to continue?")
+
+        res = message.exec_()
+        if res == QtGui.QMessageBox.No:
+            return
+
+        if message.clickedButton() == yes_new_scene_button:
+            if not self._handler.reset_current_scene():
+                self._app.log_debug("Unable to perform New Scene operation after failing to reset scene!")
+                return
+
+        # note - on nuke, we always start from a clean scene, so no need to check.
+
+        # ok scene is clear. Now switch!
+
+        # Try to create path for the context.
+        try:
+            self._handler.create_folders(ctx)
+            self._handler.restart_engine(ctx)
+        except Exception, e:
+            QtGui.QMessageBox.critical(self,
+                                       "Could not Switch!",
+                                       "Could not change work area and start a new "
+                                       "engine. This can be because the task doesn't "
+                                       "have a step. Details: %s" % e)
+            return
+
+
+        # close dialog
+        self.close()
+
     def _update_ui(self):
         """
         Update UI following a change

--- a/python/tk_multi_workfiles/ui/new_task.py
+++ b/python/tk_multi_workfiles/ui/new_task.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+
+# Form implementation generated from reading ui file 'new_task.ui'
+#
+# Created: Mon Jan 21 00:17:31 2013
+#      by: pyside-uic 0.2.13 running on PySide 1.1.0
+#
+# WARNING! All changes made in this file will be lost!
+
+from tank.platform.qt import QtCore, QtGui
+
+class Ui_NewTask(object):
+    def setupUi(self, NewTask):
+        NewTask.setObjectName("NewTask")
+        NewTask.resize(451, 289)
+        self.verticalLayout = QtGui.QVBoxLayout(NewTask)
+        self.verticalLayout.setObjectName("verticalLayout")
+        self.label_3 = QtGui.QLabel(NewTask)
+        self.label_3.setWordWrap(True)
+        self.label_3.setObjectName("label_3")
+        self.verticalLayout.addWidget(self.label_3)
+        self.gridLayout = QtGui.QGridLayout()
+        self.gridLayout.setHorizontalSpacing(20)
+        self.gridLayout.setObjectName("gridLayout")
+        self.label_4 = QtGui.QLabel(NewTask)
+        font = QtGui.QFont()
+        font.setWeight(75)
+        font.setBold(True)
+        self.label_4.setFont(font)
+        self.label_4.setObjectName("label_4")
+        self.gridLayout.addWidget(self.label_4, 2, 0, 1, 1)
+        self.entity = QtGui.QLabel(NewTask)
+        self.entity.setObjectName("entity")
+        self.gridLayout.addWidget(self.entity, 2, 1, 1, 1)
+        self.label_6 = QtGui.QLabel(NewTask)
+        font = QtGui.QFont()
+        font.setWeight(75)
+        font.setBold(True)
+        self.label_6.setFont(font)
+        self.label_6.setObjectName("label_6")
+        self.gridLayout.addWidget(self.label_6, 3, 0, 1, 1)
+        self.assigned_to = QtGui.QLabel(NewTask)
+        self.assigned_to.setObjectName("assigned_to")
+        self.gridLayout.addWidget(self.assigned_to, 3, 1, 1, 1)
+        self.label = QtGui.QLabel(NewTask)
+        font = QtGui.QFont()
+        font.setWeight(75)
+        font.setBold(True)
+        self.label.setFont(font)
+        self.label.setObjectName("label")
+        self.gridLayout.addWidget(self.label, 4, 0, 1, 1)
+        self.pipeline_step = QtGui.QComboBox(NewTask)
+        self.pipeline_step.setObjectName("pipeline_step")
+        self.gridLayout.addWidget(self.pipeline_step, 4, 1, 1, 1)
+        self.label_2 = QtGui.QLabel(NewTask)
+        font = QtGui.QFont()
+        font.setWeight(75)
+        font.setBold(True)
+        self.label_2.setFont(font)
+        self.label_2.setObjectName("label_2")
+        self.gridLayout.addWidget(self.label_2, 5, 0, 1, 1)
+        self.task_name = QtGui.QLineEdit(NewTask)
+        self.task_name.setObjectName("task_name")
+        self.gridLayout.addWidget(self.task_name, 5, 1, 1, 1)
+        self.verticalLayout.addLayout(self.gridLayout)
+        spacerItem = QtGui.QSpacerItem(20, 19, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
+        self.verticalLayout.addItem(spacerItem)
+        self.buttonBox = QtGui.QDialogButtonBox(NewTask)
+        self.buttonBox.setOrientation(QtCore.Qt.Horizontal)
+        self.buttonBox.setStandardButtons(QtGui.QDialogButtonBox.Cancel|QtGui.QDialogButtonBox.Ok)
+        self.buttonBox.setObjectName("buttonBox")
+        self.verticalLayout.addWidget(self.buttonBox)
+
+        self.retranslateUi(NewTask)
+        QtCore.QObject.connect(self.buttonBox, QtCore.SIGNAL("accepted()"), NewTask.accept)
+        QtCore.QObject.connect(self.buttonBox, QtCore.SIGNAL("rejected()"), NewTask.reject)
+        QtCore.QMetaObject.connectSlotsByName(NewTask)
+
+    def retranslateUi(self, NewTask):
+        NewTask.setWindowTitle(QtGui.QApplication.translate("NewTask", "Dialog", None, QtGui.QApplication.UnicodeUTF8))
+        self.label_3.setText(QtGui.QApplication.translate("NewTask", "<b><big>Create a new Task</big></b>\n"
+"<br><br>\n"
+"Type in a Task Name and select a Pipeline Step below.\n"
+"<br><br>", None, QtGui.QApplication.UnicodeUTF8))
+        self.label_4.setText(QtGui.QApplication.translate("NewTask", "Entity", None, QtGui.QApplication.UnicodeUTF8))
+        self.entity.setText(QtGui.QApplication.translate("NewTask", "Shot ABC 123", None, QtGui.QApplication.UnicodeUTF8))
+        self.label_6.setText(QtGui.QApplication.translate("NewTask", "Assigned to", None, QtGui.QApplication.UnicodeUTF8))
+        self.assigned_to.setText(QtGui.QApplication.translate("NewTask", "Mr John Smith", None, QtGui.QApplication.UnicodeUTF8))
+        self.label.setText(QtGui.QApplication.translate("NewTask", "Pipeline Step", None, QtGui.QApplication.UnicodeUTF8))
+        self.label_2.setText(QtGui.QApplication.translate("NewTask", "Task Name", None, QtGui.QApplication.UnicodeUTF8))
+

--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -8,23 +8,23 @@ from itertools import chain
 from datetime import datetime
 
 import tank
-from tank.platform.qt import QtCore, QtGui 
+from tank.platform.qt import QtCore, QtGui
 from tank import TankError
 from tank_vendor.shotgun_api3 import sg_timezone
 
 from .work_file import WorkFile
 
 class WorkFiles(object):
-    
+
     def __init__(self, app):
         """
         Construction
         """
         self._app = app
         self._workfiles_ui = None
-        
+
         self._user_details_cache = {}
-        
+
         # set up the work area from the app:
         self._context = None
         self._configuration_is_valid = False
@@ -32,19 +32,19 @@ class WorkFiles(object):
         self._work_area_template = None
         self._publish_template = None
         self._publish_area_template = None
-        
+
         initial_ctx = self._app.context
         if not initial_ctx or not initial_ctx:
             # TODO: load from setting
             pass
-        
+
         self._update_current_work_area(initial_ctx)
-        
+
     def show_dlg(self):
         """
-        Show the main tank file manager dialog 
+        Show the main tank file manager dialog
         """
-        
+
         from .work_files_form import WorkFilesForm
         self._workfiles_ui = self._app.engine.show_dialog("Tank File Manager", self._app, WorkFilesForm, self._app, self)
 
@@ -53,20 +53,20 @@ class WorkFiles(object):
         self._workfiles_ui.new_file.connect(self._on_new_file)
         self._workfiles_ui.show_in_fs.connect(self._on_show_in_file_system)
         self._workfiles_ui.show_in_shotgun.connect(self._on_show_in_shotgun)
-        
+
     def find_files(self, user):
         """
         Find files using the current context, work and publish templates
-        
+
         If user is specified then HumanUser should be overriden to be this
         user when resolving paths.
-        
+
         Will return a WorkFile instance for every file found in both
         work and publish areas
         """
         if not self._work_template or not self._publish_template:
             return []
-        
+
         current_user = tank.util.get_current_user(self._app.tank)
         if current_user and user and user["id"] == current_user["id"]:
             # user is current user. Set to none not to override.
@@ -80,7 +80,7 @@ class WorkFiles(object):
         if user:
             work_fields["HumanUser"] = user["login"]
         work_file_paths = self._app.tank.paths_from_template(self._work_template, work_fields, ["version"])
-        
+
         # build an index of the published file tasks to use if we don't have a task in the context:
         publish_task_map = {}
         task_id_to_task_map = {}
@@ -90,28 +90,28 @@ class WorkFiles(object):
                 if not task:
                     continue
 
-                # the key for the path-task map is the 'version zero' work file that 
+                # the key for the path-task map is the 'version zero' work file that
                 # matches this publish path.  This is constructed from the publish
                 # fields together with any additional fields from the context etc.
                 publish_fields = self._publish_template.get_fields(publish_path)
                 publish_fields["version"] = 0
                 work_path_key = self._work_template.apply_fields(dict(chain(work_fields.iteritems(), publish_fields.iteritems())))
-                
+
                 task_id_to_task_map[task["id"]] = task
                 publish_task_map.setdefault(work_path_key, set()).add(task["id"])
-         
+
         # add entries for work files:
         file_details = []
         handled_publish_files = set()
-        
+
         for work_path in work_file_paths:
             # resolve the publish path:
             fields = self._work_template.get_fields(work_path)
             publish_path = self._publish_template.apply_fields(fields)
-            
+
             handled_publish_files.add(publish_path)
             publish_details = publish_file_details.get(publish_path)
-                
+
             # create file entry:
             details = {}
             if "version" in fields:
@@ -121,7 +121,7 @@ class WorkFiles(object):
 
             # entity is always the context entity:
             details["entity"] = self._context.entity
-            
+
             if publish_details:
                 # add other info from publish:
                 details["task"] = publish_details.get("task")
@@ -149,37 +149,37 @@ class WorkFiles(object):
                             task_ids = publish_task_map.get(key)
                             if task_ids and len(task_ids) == 1:
                                 task = task_id_to_task_map[list(task_ids)[0]]
-                            
+
                     details["task"] = task
 
                 # get the local file modified time - ensure it has a time-zone set:
                 details["modified_time"] = datetime.fromtimestamp(os.path.getmtime(work_path), tz=sg_timezone.local)
-                
+
                 # get the last modified by:
                 last_user = self._get_file_last_modified_user(work_path)
                 details["modified_by"] = last_user
 
             file_details.append(WorkFile(work_path, publish_path, True, publish_details != None, details))
-         
+
         # add entries for any publish files that don't have a work file
         for publish_path, publish_details in publish_file_details.iteritems():
             if publish_path in handled_publish_files:
                 continue
-                
+
             # resolve the work path using work template fields + publish fields:
             publish_fields = self._publish_template.get_fields(publish_path)
             work_path = self._work_template.apply_fields(dict(chain(work_fields.iteritems(), publish_fields.iteritems())))
 
             # create file entry:
             is_work_file = (work_path in work_file_paths)
-            details = {}            
+            details = {}
             if "version" in publish_fields:
                 details["version"] = publish_fields["version"]
             if "name" in publish_fields:
                 details["name"] = publish_fields["name"]
 
             details["entity"] = self._context.entity
-                
+
             # add additional details from publish record:
             details["task"] = publish_details.get("task")
             details["thumbnail"] = publish_details.get("image")
@@ -187,11 +187,11 @@ class WorkFiles(object):
             details["modified_by"] = publish_details.get("created_by", {})
             details["publish_description"] = publish_details.get("description")
             details["published_file_id"] = publish_details.get("published_file_id")
-                
-            file_details.append(WorkFile(work_path, publish_path, is_work_file, True, details))            
+
+            file_details.append(WorkFile(work_path, publish_path, is_work_file, True, details))
 
         return file_details
-        
+
     def _on_show_in_file_system(self, work_area, user):
         """
         Show the work area/publish area path in the file system
@@ -201,31 +201,31 @@ class WorkFiles(object):
             template = self._work_area_template if work_area else self._publish_area_template
             if not self._context or not template:
                 return
-            
+
             # now build fields to construct path with:
             fields = self._context.as_template_fields(template)
             if user:
                 fields["HumanUser"] = user["login"]
-                
+
             # try to build a path from the template with these fields:
             while template and template.missing_keys(fields):
                 template = template.parent
             if not template:
                 # failed to find a template with no missing keys!
                 return
-            
+
             # build the path:
             path = template.apply_fields(fields)
         except TankError, e:
             return
-        
+
         # now find the deepest path that actually exists:
         while path and not os.path.exists(path):
             path = os.path.dirname(path)
         if not path:
             return
         path = path.replace("/", os.path.sep)
-        
+
         # build the command:
         system = sys.platform
         if system == "linux2":
@@ -236,45 +236,45 @@ class WorkFiles(object):
             cmd = "cmd.exe /C start \"Folder\" \"%s\"" % path
         else:
             raise TankError("Platform '%s' is not supported." % system)
-        
+
         # run the command:
         exit_code = os.system(cmd)
         if exit_code != 0:
-            self._app.log_error("Failed to launch '%s'!" % cmd)     
-        
+            self._app.log_error("Failed to launch '%s'!" % cmd)
+
     def _on_show_in_shotgun(self, file):
         """
         Show the specified published file in shotgun
         """
         if not file.is_published or file.published_file_id is None:
             return
-        
+
         # construct and open the url:
         published_file_entity_type = tank.util.get_published_file_entity_type(self._app.tank)
         url = "%s/detail/%s/%d" % (self._app.tank.shotgun.base_url, published_file_entity_type, file.published_file_id)
         QtGui.QDesktopServices.openUrl(QtCore.QUrl(url))
-        
+
     def have_valid_configuration_for_work_area(self):
         return self._configuration_is_valid
-        
+
     def can_do_new_file(self):
         """
         Do some validation to see if it's possible to
         start a new file with the selected context.
         """
         if (not self._context
-            or not self._context.entity 
+            or not self._context.entity
             or not self._work_area_template):
             return False
-        
+
         # ensure that context contains everything required by the work area template:
         ctx_fields = self._context.as_template_fields(self._work_area_template)
         if self._work_area_template.missing_keys(ctx_fields):
             return False
-        
+
         return True
-        
-    def _reset_current_scene(self):
+
+    def reset_current_scene(self):
         """
         Use hook to clear the current scene
         """
@@ -282,55 +282,55 @@ class WorkFiles(object):
         if res == None or not isinstance(res, bool):
             raise TankError("Unexpected type returned from 'hook_scene_operation' - expected 'bool' but returned '%s'" % type(res).__name__)
         return res
-    
+
     def _open_file(self, path):
         """
         Use hook to open the specified file.
         """
         # do open:
         self._app.execute_hook("hook_scene_operation", operation="open", file_path=path, context = self._context)
-        
+
     def _copy_file(self, source_path, target_path):
         """
         Use hook to copy a file from source to target path
         """
-        self._app.execute_hook("hook_copy_file", 
-                               source_path=source_path, 
+        self._app.execute_hook("hook_copy_file",
+                               source_path=source_path,
                                target_path=target_path)
-        
+
     def _save_file(self):
         """
         Use hook to save the current file
         """
         self._app.execute_hook("hook_scene_operation", operation="save", file_path=None, context = self._context)
-        
-    def _restart_engine(self, ctx):
+
+    def restart_engine(self, ctx):
         """
         Set context to the new context.  This will
         clear the current scene and restart the
         current engine with the specified context
         """
-        # restart engine:        
+        # restart engine:
         try:
             current_engine_name = self._app.engine.name
-            
-            # stop current engine:            
-            if tank.platform.current_engine(): 
+
+            # stop current engine:
+            if tank.platform.current_engine():
                 tank.platform.current_engine().destroy()
-                
+
             # start engine with new context:
             tank.platform.start_engine(current_engine_name, ctx.tank, ctx)
         except Exception, e:
             raise TankError("Failed to change work area and start a new engine - %s" % e)
-        
-    def _create_folders(self, ctx):
+
+    def create_folders(self, ctx):
         """
         Create folders for specified context
         """
         # create folders:
         ctx_entity = ctx.task if ctx.task else ctx.entity
         self._app.tank.create_filesystem_structure(ctx_entity.get("type"), ctx_entity.get("id"), engine=self._app.engine.name)
-        
+
     def _on_open_file(self, file, is_previous_version):
         """
         Main function used to open a file when requested by the UI
@@ -340,10 +340,10 @@ class WorkFiles(object):
 
         # get the path of the file to open.  Handle
         # other user sandboxes and publishes if need to
-        
+
         src_path = None
         work_path = None
-        
+
         if is_previous_version:
             # if the file is a previous version then we just open it
             # rather than attempting to copy it
@@ -353,94 +353,94 @@ class WorkFiles(object):
                 work_path = file.publish_path
                 if not os.path.exists(work_path):
                     QtGui.QMessageBox.critical(self._workfiles_ui, "File doesn't exist!", "The published file\n\n%s\n\nCould not be found to open!" % work_path)
-                    return 
+                    return
         else:
             # what we do depends on the current location of the file
-            
+
             if file.is_local:
                 # trying to open a work file...
                 work_path = file.path
-    
-                try:                
+
+                try:
                     fields = self._work_template.get_fields(work_path)
                 except TankError, e:
-                    QtGui.QMessageBox.critical(self._workfiles_ui, "Failed to resolve file path", 
+                    QtGui.QMessageBox.critical(self._workfiles_ui, "Failed to resolve file path",
                                            "Failed to resolve file path:\n\n%s\n\nagainst work template:\n\n%s\n\nUnable to open file!" % (work_path, e))
                     return
                 except Exception, e:
                     self._app.log_exception("Failed to resolve file path %s against work template" % work_path)
                     return
-                
+
                 # check if file is in this users sandbox or another users:
                 user = fields.get("HumanUser")
                 if user:
                     current_user = tank.util.get_current_user(self._app.tank)
                     if current_user and current_user["login"] != user:
-                        
+
                         fields["HumanUser"] = current_user["login"]
                         # TODO: do we need to version up as well??
                         local_path = self._work_template.apply_fields(fields)
-                        
+
                         if local_path != work_path:
-                            
+
                             # get the actual user:
                             sg_user = self._get_user_details(user)
                             if sg_user:
                                 user = sg_user.get("name", user)
-                            
+
                             # more than just an open so prompt user to confirm:
                             #TODO: replace with tank dialog
                             answer = QtGui.QMessageBox.question(self._workfiles_ui, "Open file from other user?",
                                                                 ("The work file you are opening:\n\n%s\n\n"
                                                                 "is in a user sandbox belonging to %s.  Would "
-                                                                "you like to copy the file to your sandbox and open it?" % (work_path, user)), 
+                                                                "you like to copy the file to your sandbox and open it?" % (work_path, user)),
                                                                 QtGui.QMessageBox.Yes | QtGui.QMessageBox.Cancel)
                             if answer == QtGui.QMessageBox.Cancel:
                                 return
-    
+
                             src_path = work_path
                             work_path = local_path
-    
+
             else:
                 # trying to open a publish:
                 src_path = file.publish_path
-                
+
                 if not os.path.exists(src_path):
                     QtGui.QMessageBox.critical(self._workfiles_ui, "File doesn't exist!", "The published file\n\n%s\n\nCould not be found to open!" % src_path)
-                    return 
-                
+                    return
+
                 new_version = None
-                
+
                 # get the work path for the publish:
-                try:                
+                try:
                     fields = self._publish_template.get_fields(src_path)
-                    
+
                     # add additional fields:
                     current_user = tank.util.get_current_user(self._app.tank)
                     if current_user:
                         # populate if current user is defined.
                         fields["HumanUser"] = current_user.get("login")
-    
-                    # get next version:                
+
+                    # get next version:
                     new_version = self._get_next_available_version(fields)
                     fields["version"] = new_version
-                    
+
                     # construct work path:
                     work_path = self._work_template.apply_fields(fields)
                 except TankError, e:
-                    QtGui.QMessageBox.critical(self._workfiles_ui, "Failed to get work file path", 
+                    QtGui.QMessageBox.critical(self._workfiles_ui, "Failed to get work file path",
                                            "Failed to resolve work file path from publish path:\n\n%s\n\n%s\n\nUnable to open file!" % (src_path, e))
                     return
                 except Exception, e:
                     self._app.log_exception("Failed to resolve work file path from publish path: %s" % src_path)
                     return
-                
+
                 # prompt user to confirm:
                 answer = QtGui.QMessageBox.question(self._workfiles_ui, "Open file from publish area?",
                                                                 ("The published file:\n\n%s\n\n"
                                                                 "will be copied to your work area, versioned "
                                                                 "up to v%03d and then opened.\n\n"
-                                                                "Would you like to continue?" % (src_path, new_version)), 
+                                                                "Would you like to continue?" % (src_path, new_version)),
                                                                 QtGui.QMessageBox.Yes | QtGui.QMessageBox.Cancel)
                 if answer == QtGui.QMessageBox.Cancel:
                     return
@@ -452,56 +452,56 @@ class WorkFiles(object):
         if not work_path or not new_ctx:
             # can't do anything!
             return
-           
+
         if new_ctx != self._app.context:
             # ensure folders exist.  This serves the
             # dual purpose of populating the path
             # cache and ensuring we can copy the file
             # if we need to
             try:
-                self._create_folders(new_ctx)
+                self.create_folders(new_ctx)
             except TankError, e:
-                QtGui.QMessageBox.critical(self._workfiles_ui, "Failed to create folders!", 
+                QtGui.QMessageBox.critical(self._workfiles_ui, "Failed to create folders!",
                                            "Failed to create folders:\n\n%s!" % e)
                 return
             except Exception, e:
                 self._app.log_exception("Failed to create folders")
                 return
-        
+
         # if need to, copy file
         if src_path:
             # check that local path doesn't already exist:
             if os.path.exists(work_path):
                 #TODO: replace with tank dialog
                 answer = QtGui.QMessageBox.question(self._workfiles_ui, "Overwrite file?",
-                                                "The file\n\n%s\n\nalready exists.  Would you like to overwrite it?" % (work_path), 
+                                                "The file\n\n%s\n\nalready exists.  Would you like to overwrite it?" % (work_path),
                                                 QtGui.QMessageBox.Yes | QtGui.QMessageBox.Cancel)
                 if answer == QtGui.QMessageBox.Cancel:
                     return
-                
+
             try:
                 # copy file:
                 self._copy_file(src_path, work_path)
             except TankError, e:
-                QtGui.QMessageBox.critical(self._workfiles_ui, "Copy file failed!", 
+                QtGui.QMessageBox.critical(self._workfiles_ui, "Copy file failed!",
                                            "Copy of file failed!\n\n%s!" % e)
                 return
             except Exception, e:
                 self._app.log_exception("Copy file failed")
-                return            
-                    
+                return
+
         # switch context (including do new file):
         try:
             # reset the current scene:
-            if not self._reset_current_scene():
+            if not self.reset_current_scene():
                 self._app.log_debug("Unable to perform New Scene operation after failing to reset scene!")
                 return
-            
+
             if new_ctx != self._app.context:
                 # restart the engine with the new context
-                self._restart_engine(new_ctx)
+                self.restart_engine(new_ctx)
         except TankError, e:
-            QtGui.QMessageBox.critical(self._workfiles_ui, "Failed to change work area", 
+            QtGui.QMessageBox.critical(self._workfiles_ui, "Failed to change work area",
                                        "Failed to change the work area to '%s':\n\n%s\n\nUnable to continue!" % (new_ctx, e))
             return
         except Exception, e:
@@ -512,13 +512,13 @@ class WorkFiles(object):
         try:
             self._open_file(work_path)
         except TankError, e:
-            QtGui.QMessageBox.critical(self._workfiles_ui, "Failed to open file", 
+            QtGui.QMessageBox.critical(self._workfiles_ui, "Failed to open file",
                                        "Failed to open file\n\n%s\n\n%s" % (work_path, e))
             return
         except Exception, e:
             self._app.log_exception("Failed to open file %s!" % work_path)
             return
-        
+
         # close work files UI as it will no longer
         # be valid anyway as the context has changed
         self._workfiles_ui.close()
@@ -541,18 +541,18 @@ class WorkFiles(object):
         try:
             if self._context != self._app.context:
                 # ensure folders exist:
-                self._create_folders(self._context)
+                self.create_folders(self._context)
 
             # reset the current scene:
-            if not self._reset_current_scene():
+            if not self.reset_current_scene():
                 self._app.log_debug("Unable to perform New Scene operation after failing to reset scene!")
                 return
 
-            if self._context != self._app.context:            
+            if self._context != self._app.context:
                 # restart the engine with the new context
-                self._restart_engine(self._context)
+                self.restart_engine(self._context)
         except TankError, e:
-            QtGui.QMessageBox.information(self._workfiles_ui, "Something went wrong!", 
+            QtGui.QMessageBox.information(self._workfiles_ui, "Something went wrong!",
                                        "Something went wrong:\n\n%s!" % e)
             return
         except Exception, e:
@@ -561,53 +561,56 @@ class WorkFiles(object):
 
         # close work files UI:
         self._workfiles_ui.close()
-        
+
     def get_current_work_area(self):
         """
         Get the current work area/context
         """
         return self._context
-        
-    def change_work_area(self):
+
+    def change_work_area(self, do_switch_context=False):
         """
         Show a ui for the user to select a new work area/context
         """
         from .select_work_area_form import SelectWorkAreaForm
-        (res, widget) = self._app.engine.show_modal("Pick a Work Area", self._app, SelectWorkAreaForm, self._app, self)
-        
-        # make sure to explicitly call close so 
-        # that browser threads are cleaned up
-        # correctly
-        widget.close()
-        
-        if res == QtGui.QDialog.Accepted:
-            
-            # update the current work area:
-            self._update_current_work_area(widget.context)
-            
-            # and return it:
-            return self._context
+        if not do_switch_context:
+            (res, widget) = self._app.engine.show_modal("Pick a Work Area", self._app, SelectWorkAreaForm, self._app, self)
+            # make sure to explicitly call close so
+            # that browser threads are cleaned up
+            # correctly
+            widget.close()
+
+            if res == QtGui.QDialog.Accepted:
+
+                # update the current work area:
+                self._update_current_work_area(widget.context)
+
+                # and return it:
+                return self._context
+        else:
+            self._set_context_ui = self._app.engine.show_dialog("Pick a Work Area", self._app, SelectWorkAreaForm, self._app, self)
+            self._set_context_ui.change_context_mode = True
 
         return None
-        
+
     def create_new_task(self):
         """
-        Called when user clicks the new task button 
+        Called when user clicks the new task button
         on the select work area form
         """
-        raise NotImplementedError     
-    
+        raise NotImplementedError
+
     def _update_current_work_area(self, ctx):
         """
         Update the current work area being used
         """
         if self._context != ctx:
-            
+
             # update templates for the new context:
             templates = {}
             try:
-                templates = self._get_templates_for_context(ctx, ["template_work", 
-                                                                  "template_work_area", 
+                templates = self._get_templates_for_context(ctx, ["template_work",
+                                                                  "template_work_area",
                                                                   "template_publish",
                                                                   "template_publish_area"])
             except TankError, e:
@@ -616,17 +619,17 @@ class WorkFiles(object):
                 self._configuration_is_valid = False
             else:
                 self._configuration_is_valid = True
-            
+
             #if templates is not None:
             self._work_template = templates.get("template_work")
             self._work_area_template = templates.get("template_work_area")
             self._publish_template = templates.get("template_publish")
             self._publish_area_template = templates.get("template_publish_area")
             self._context = ctx
-                    
+
             # TODO: validate templates?
-    
-        
+
+
     def _get_user_details(self, login_name):
         """
         Get the shotgun HumanUser entry:
@@ -641,11 +644,11 @@ class WorkFiles(object):
                 pass
             self._user_details_cache[login_name] = sg_user
         return sg_user
-        
+
     def _get_file_last_modified_user(self, path):
         """
         Get the user details of the last person
-        to modify the specified file        
+        to modify the specified file
         """
         login_name = None
         if sys.platform == "win32":
@@ -653,69 +656,69 @@ class WorkFiles(object):
             pass
         else:
             try:
-                from pwd import getpwuid                
+                from pwd import getpwuid
                 login_name = getpwuid(os.stat(path).st_uid).pw_name
             except:
                 pass
-        
+
         if login_name:
             return self._get_user_details(login_name)
-        
+
         return None
-                        
+
     def _get_published_file_details(self):
         """
         Get the details of all published files that
         match the current publish template.
         """
-        
+
         # get list of published files for entity:
         filters = [["entity", "is", self._context.entity]]
         if self._context.task:
             filters.append(["task", "is", self._context.task])
-        
+
         published_file_entity_type = tank.util.get_published_file_entity_type(self._app.tank)
         sg_publish_fields = ["description", "version_number", "image", "created_at", "created_by", "name", "path", "task", "description"]
         sg_published_files = self._app.shotgun.find(published_file_entity_type, filters, sg_publish_fields)
-        
+
         publish_files = {}
         for sg_file in sg_published_files:
 
             path = sg_file.get("path").get("local_path")
 
-            # make sure path matches publish template:            
+            # make sure path matches publish template:
             if not self._publish_template.validate(path):
                 continue
-                
+
             details = sg_file.copy()
             details["path"] = path
             details["published_file_id"] = sg_file.get("id")
-            
+
             publish_files[path] = details
-            
+
         return publish_files
-    
+
     def get_usersandbox_users(self):
         """
-        Find all available user sandbox users for the 
+        Find all available user sandbox users for the
         current work area.
         """
         if not self._work_area_template:
             return
-        
+
         # use the fields for the current context to get a list of work area paths:
         fields = self._context.as_template_fields(self._work_area_template)
         work_area_paths = self._app.tank.paths_from_template(self._work_area_template, fields, ["HumanUser"])
-        
+
         # from paths, find a unique list of user's:
         users = set()
         for path in work_area_paths:
-            
+
             fields = self._work_area_template.get_fields(path)
             user = fields.get("HumanUser")
-            if user: 
+            if user:
                 users.add(user)
-        
+
         # first look for details in cache:
         user_details = []
         users_to_fetch = []
@@ -726,7 +729,7 @@ class WorkFiles(object):
             else:
                 if details:
                     user_details.append(details)
-                
+
         if users_to_fetch:
             # get remaining details from shotgun:
             filter = ["login", "in"] + list(users_to_fetch)
@@ -738,18 +741,18 @@ class WorkFiles(object):
                 login = sg_user.get("login")
                 if login not in users_to_fetch:
                     continue
-                
+
                 self._user_details_cache[login] = sg_user
                 user_details.append(sg_user)
                 users_found.add(login)
-            
+
             # and fill in any blanks so we don't bother searching again:
             for user in users_to_fetch:
                 if user not in users_found:
                     self._user_details_cache[user] = {}
-                
+
         return user_details
-        
+
     def _get_templates_for_context(self, context, keys):
         """
         Find templates for the given context.
@@ -759,37 +762,37 @@ class WorkFiles(object):
             raise TankError("Failed to find Work Files settings for context '%s'.\n\nPlease ensure that"
                             " the Work Files app is installed for the environment that will be used for"
                             " this context" % context)
-        
+
         templates = {}
         for key in keys:
             template = self._app.get_template_from(settings, key)
             templates[key] = template
-            
+
         return templates
-            
-        
+
+
     def _get_app_settings_for_context(self, context):
         """
         Find settings for the app in the specified context
         """
         if not context:
             return
-        
-        # find settings for all instances of app in 
+
+        # find settings for all instances of app in
         # the environment picked for the given context:
         other_settings = tank.platform.find_app_settings(self._app.engine.name, self._app.name, self._app.tank, context)
-        
+
         if len(other_settings) == 1:
             return other_settings[0].get("settings")
-    
+
         settings_by_engine = {}
         for settings in other_settings:
             settings_by_engine.setdefault(settings.get("engine_instance"), list()).append(settings)
-        
-        # can't handle more than one engine!  
+
+        # can't handle more than one engine!
         if len(settings_by_engine) != 1:
             return
-            
+
         # ok, so have a single engine but multiple apps
         # lets try to find an app with the same instance
         # name:
@@ -800,14 +803,14 @@ class WorkFiles(object):
                 break
         if not app_instance_name:
             return
-    
+
         for engine_name, engine_settings in settings_by_engine.iteritems():
             for settings in engine_settings:
                 if settings.get("app_instance") == app_instance_name:
                     return settings.get("settings")
-        
 
-    
-    
-    
-    
+
+
+
+
+


### PR DESCRIPTION
This is kind of a big change.  fundamentally nothing really has changed with how the tool works.  It has really only been given a second use.

Some users wanted the ability to switch contexts without affecting their currently open scene.  I was going to edit tk-multi-setcontext but it seems like that may be an app on the decline.  tk-multi-workfiles has tk-multi-setcontext hidden in there so I thought that it would be good to utilize the code already written for tk-multi-workfiles and allow it to be used as tk-multi-setcontext was used before.

It only required slight modifications in the end.  I also added the ability to create a new task (taken from tk-multi-setcontext).

Another enhancement is I modified the maya and nuke hooks to try to use the Tank Save As and Snapshot tools first when resetting a scene.  If they fail, it falls back to the native way of doing either a save as or a save.  I will add for softimage as well.

I hope this isn't being too presumptuous...

-tony

*Note: This was branched from v0.2.16
