### PR TITLE
Makes platform scene hooks consistent and try to use Tank apps first.

### DIFF
--- a/hooks/scene_operation_tk-3dsmax.py
+++ b/hooks/scene_operation_tk-3dsmax.py
@@ -12,38 +12,36 @@ from tank import TankError
 
 class SceneOperation(Hook):
     """
-    Hook called to perform an operation with the 
+    Hook called to perform an operation with the
     current scene
     """
-    
+
     def execute(self, operation, file_path, context, **kwargs):
         """
         Main hook entry point
-        
+
         :operation: String
                     Scene operation to perform
-        
+
         :file_path: String
                     File path to use if the operation
                     requires it (e.g. open)
-               
+
         :context:   Context
                     The context the file operation is being
                     performed in.
-                    
+
         :returns:   Depends on operation:
                     'current_path' - Return the current scene
                                      file path as a String
-                    'reset'        - True if scene was reset to an empty 
+                    'reset'        - True if scene was reset to an empty
                                      state, otherwise False
                     all others     - None
         """
-        
+
         if operation == "current_path":
             # return the current scene path
-            if not mxs.maxFileName:
-                return ""
-            return os.path.join(mxs.maxFilePath, mxs.maxFileName)
+            return self.get_scene_path()
         elif operation == "open":
             # open the specified scene
             mxs.loadMaxFile(file_path)
@@ -58,16 +56,45 @@ class SceneOperation(Hook):
             """
             Reset the scene to an empty state
             """
-            # use the standard Max mechanism to check
-            # for and save the file if required:
-            if not mxs.checkForSave():
-                return False
-            
+            while mxs.getSaveRequired():
+                # changes have been made to the scene
+                res = QtGui.QMessageBox.question(None,
+                                                 "Save your script?",
+                                                 "Your script has unsaved changes. Save before proceeding?",
+                                                 QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
+
+                if res == QtGui.QMessageBox.Cancel:
+                    return False
+                elif res == QtGui.QMessageBox.No:
+                    break
+                # Lets try to use the built in Tank svene features first.
+                try:
+                    engine = tank.platform.current_engine()
+                    if self.get_scene_path():
+                        snapshot = engine.commands.get("Snapshot...")
+                        snapshot.get("callback")()
+                    else:
+                        tank_save = engine.commands.get("Tank Save As...")
+                        tank_save.get("callback")()
+                except:
+                    # Saving via Tank failed for some reason.
+                    # use the standard Max mechanism to check
+                    # for and save the file if required:
+                    if not mxs.checkForSave():
+                        return False
+
             # now reset the scene:
             mxs.resetMAXFile(mxs.pyhelper.namify("noPrompt"))
-            
             return True
         else:
             raise TankError("Don't know how to perform scene operation '%s'" % operation)
+
+    def get_scene_path(self):
+        """
+        Returns the current scene path
+        """
+        if not mxs.maxFileName:
+            return ""
+        return os.path.join(mxs.maxFilePath, mxs.maxFileName)
 
 

--- a/hooks/scene_operation_tk-maya.py
+++ b/hooks/scene_operation_tk-maya.py
@@ -13,29 +13,29 @@ from tank.platform.qt import QtGui
 
 class SceneOperation(Hook):
     """
-    Hook called to perform an operation with the 
+    Hook called to perform an operation with the
     current scene
     """
-    
+
     def execute(self, operation, file_path, context, **kwargs):
         """
         Main hook entry point
-        
+
         :operation: String
                     Scene operation to perform
-        
+
         :file_path: String
                     File path to use if the operation
                     requires it (e.g. open)
-        
+
         :context:   Context
                     The context the file operation is being
                     performed in.
-                    
+
         :returns:   Depends on operation:
                     'current_path' - Return the current scene
                                      file path as a String
-                    'reset'        - True if scene was reset to an empty 
+                    'reset'        - True if scene was reset to an empty
                                      state, otherwise False
                     all others     - None
         """
@@ -43,9 +43,9 @@ class SceneOperation(Hook):
             # return the current scene path
             return cmds.file(query=True, sceneName=True)
         elif operation == "open":
-            # do new scene as Maya doesn't like opening 
-            # the scene it currently has open!   
-            cmds.file(new=True, force=True) 
+            # do new scene as Maya doesn't like opening
+            # the scene it currently has open!
+            cmds.file(new=True, force=True)
             cmds.file(file_path, open=True)
         elif operation == "save":
             # save the current scene:
@@ -53,7 +53,7 @@ class SceneOperation(Hook):
         elif operation == "save_as":
             # first rename the scene as file_path:
             cmds.file(rename=file_path)
-            
+
             # Maya can choose the wrong file type so
             # we should set it here explicitely based
             # on the extension
@@ -62,13 +62,13 @@ class SceneOperation(Hook):
                 maya_file_type = "mayaAscii"
             elif file_path.lower().endswith(".mb"):
                 maya_file_type = "mayaBinary"
-            
+
             # save the scene:
             if maya_file_type:
                 cmds.file(save=True, force=True, type=maya_file_type)
             else:
                 cmds.file(save=True, force=True)
-                
+
         elif operation == "reset":
             """
             Reset the scene to an empty state
@@ -79,19 +79,28 @@ class SceneOperation(Hook):
                                                  "Save your scene?",
                                                  "Your scene has unsaved changes. Save before proceeding?",
                                                  QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
-            
+
                 if res == QtGui.QMessageBox.Cancel:
                     return False
                 elif res == QtGui.QMessageBox.No:
                     break
                 else:
                     scene_name = cmds.file(query=True, sn=True)
-                    if not scene_name:
-                        cmds.SaveSceneAs()
-                    else:
-                        cmds.file(save=True)
-            
-            # do new file:    
+                    try:
+                        engine = tank.platform.current_engine()
+                        if scene_name:
+                            snapshot = engine.commands.get("Snapshot...")
+                            snapshot.get("callback")()
+                        else:
+                            tank_save = engine.commands.get("Tank Save As...")
+                            tank_save.get("callback")()
+                    except:
+                        if scene_name:
+                            cmds.file(save=True)
+                        else:
+                            cmds.SaveSceneAs()
+
+            # do new file:
             cmds.file(newFile=True, force=True)
             return True
         else:

--- a/hooks/scene_operation_tk-nuke.py
+++ b/hooks/scene_operation_tk-nuke.py
@@ -13,69 +13,69 @@ from tank.platform.qt import QtGui
 
 class SceneOperation(Hook):
     """
-    Hook called to perform an operation with the 
+    Hook called to perform an operation with the
     current scene
     """
-    
+
     def execute(self, operation, file_path, context, **kwargs):
         """
         Main hook entry point
-        
+
         :operation: String
                     Scene operation to perform
-        
+
         :file_path: String
                     File path to use if the operation
                     requires it (e.g. open)
-                    
+
         :context:   Context
                     The context the file operation is being
                     performed in.
-                    
+
         :returns:   Depends on operation:
                     'current_path' - Return the current scene
                                      file path as a String
-                    'reset'        - True if scene was reset to an empty 
+                    'reset'        - True if scene was reset to an empty
                                      state, otherwise False
                     all others     - None
         """
-        
+
         if file_path:
             file_path = file_path.replace("/", os.path.sep)
-        
+
         if operation == "current_path":
             # return the current script path
             return nuke.root().name().replace("/", os.path.sep)
-        
+
         elif operation == "open":
             # open the specified script
             nuke.scriptOpen(file_path)
-            
+
             # reset any write node render paths:
             if self._reset_write_node_render_paths():
                 # something changed so make sure to save the script again:
                 nuke.scriptSave()
-            
+
         elif operation == "save":
             # save the current script:
             nuke.scriptSave()
-            
+
         elif operation == "save_as":
             old_path = nuke.root()["name"].value()
             try:
                 # rename script:
                 nuke.root()["name"].setValue(file_path)
-                        
+
                 # reset all write nodes:
                 self._reset_write_node_render_paths()
-                    
+
                 # save script:
-                nuke.scriptSaveAs(file_path, -1)    
+                nuke.scriptSaveAs(file_path, -1)
             except Exception, e:
                 # something went wrong so reset to old path:
                 nuke.root()["name"].setValue(old_path)
                 raise TankError("Failed to save scene %s", e)
-            
+
         elif operation == "reset":
             """
             Reset the scene to an empty state
@@ -86,22 +86,33 @@ class SceneOperation(Hook):
                                                  "Save your script?",
                                                  "Your script has unsaved changes. Save before proceeding?",
                                                  QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
-            
+
                 if res == QtGui.QMessageBox.Cancel:
                     return False
                 elif res == QtGui.QMessageBox.No:
                     break
                 else:
-                    nuke.scriptSave()
+                    # if nukes root name is Root it has never been saved
+                    # so try to run Save As... otherwise use Snapshot.
+                    try:
+                        engine = tank.platform.current_engine()
+                        if nuke.root().name() == "Root":
+                            tank_save = engine.commands.get("Tank Save As...")
+                            tank_save.get("callback")()
+                        else:
+                            snapshot = engine.commands.get("Snapshot...")
+                            snapshot.get("callback")()
+                    except:
+                        nuke.scriptSave()
 
-            # now clear the script:
+            # now clear the script and create a default Viewer node:
             nuke.scriptClear()
-            
+            nuke.createNode("Viewer")
             return True
         else:
             raise TankError("Don't know how to perform scene operation '%s'" % operation)
-        
-        
+
+
     def _reset_write_node_render_paths(self):
         """
         Use the tk-nuke-writenode app interface to find and reset
@@ -110,11 +121,11 @@ class SceneOperation(Hook):
         write_node_app = self.parent.engine.apps.get("tk-nuke-writenode")
         if not write_node_app:
             return
-        
+
         write_nodes = write_node_app.get_write_nodes()
         for write_node in write_nodes:
             write_node_app.reset_node_render_path(write_node)
-            
+
         return len(write_nodes) > 0
-        
-        
+
+

--- a/hooks/scene_operation_tk-softimage.py
+++ b/hooks/scene_operation_tk-softimage.py
@@ -18,38 +18,32 @@ Application = Dispatch("XSI.Application").Application
 
 class SceneOperation(Hook):
     """
-    Hook called to perform an operation with the 
+    Hook called to perform an operation with the
     current scene
     """
-    
+
     def execute(self, operation, file_path, **kwargs):
         """
         Main hook entry point
-        
+
         :operation: String
                     Scene operation to perform
-        
+
         :file_path: String
                     File path to use if the operation
                     requires it (e.g. open)
-                    
+
         :returns:   Depends on operation:
                     'current_path' - Return the current scene
                                      file path as a String
-                    'reset'        - True if scene was reset to an empty 
+                    'reset'        - True if scene was reset to an empty
                                      state, otherwise False
                     all others     - None
         """
-        
+
         if operation == "current_path":
-            # return the current scene path
-            scene_name = Application.ActiveProject.ActiveScene.Name
-            scene_filename = Application.ActiveProject.ActiveScene.filename.value
-            # If the scene name is "Scene" rather than "Untitled", we can be reasonably
-            # sure that we haven't opened a file called Untitled.scn
-            if scene_name == "Scene" and os.path.basename(scene_filename) == "Untitled.scn":
-                return ""
-            return scene_filename
+            # returns the current scene path.
+            return self.get_scene_path()
 
         elif operation == "open":
             # open the specified scene
@@ -65,14 +59,66 @@ class SceneOperation(Hook):
 
         elif operation == "reset":
             # reset the scene to an empty state
-            try:
-                # use the standard Softimage mechanism to check
-                # for and save the file if required:
-                Application.NewScene("", 1)
-            except com_error:
-                # exception here means the user hit 'Cancel'
-                return False
-            else:
+            if not self.scene_dirty():
                 return True
+
+            while self.scene_dirty():
+                # changes have been made to the scene
+                res = QtGui.QMessageBox.question(None,
+                                                 "Save your script?",
+                                                 "Your script has unsaved changes. Save before proceeding?",
+                                                 QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
+
+                if res == QtGui.QMessageBox.Cancel:
+                    return False
+                elif res == QtGui.QMessageBox.No:
+                    break
+                try:
+                    engine = tank.platform.current_engine()
+                    if self.get_scene_name():
+                        snapshot = engine.commands.get("Snapshot...")
+                        snapshot.get("callback")()
+                    else:
+                        tank_save = engine.commands.get("Tank Save As...")
+                        tank_save.get("callback")()
+                except:
+                    # Either the scene wasn't dirty or we failed trying to use the
+                    # built in Tank saving functionality.
+                    # We'll try using the standard saving mechanism then.
+                    try:
+                        # use the standard Softimage mechanism to check
+                        # for and save the file if required:
+                        Application.NewScene("", 1)
+                    except com_error:
+                        # exception here means the user hit 'Cancel'
+                        return False
+            Application.NewScene("", 0)
+            return True
         else:
             raise TankError("Don't know how to perform scene operation '%s'" % operation)
+
+    def scene_dirty(self):
+        """
+        Returns True if the current scene is dirty
+        """
+        dirty_count = Application.GetValue("Project.dirtycount")
+        if dirty_count:
+            return True
+        for model in Application.ActiveSceneRoot.Models:
+            dirty_count = model.GetPropertyFromName("dirty_count")
+            if dirty_count:
+                return True
+        return False
+
+    def get_scene_path(self):
+        """
+        Returns the current scene path.
+        """
+        # return the current scene path
+        scene_name = Application.ActiveProject.ActiveScene.Name
+        scene_filename = Application.ActiveProject.ActiveScene.filename.value
+        # If the scene name is "Scene" rather than "Untitled", we can be reasonably
+        # sure that we haven't opened a file called Untitled.scn
+        if scene_name == "Scene" and os.path.basename(scene_filename) == "Untitled.scn":
+            return ""
+        return scene_filename


### PR DESCRIPTION
When scene "reset" is called, an attempt is made to use the Tank Save As or Tank snapshot.  If these fail then resort back to using the applications built in save functionality.

This patch also attempts to make the hooks more consistent.
