### PR TITLE
I hope this is right to make a pull request

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -61,6 +61,14 @@ configuration:
         description: Specify a hook that will be used to copy the file 'source_path' 
                      to 'target_path'.
            
+#add filter extension         
+    file_extensions:
+        type: list
+        description: "List of file extensions shown in the work files view."
+        values:
+            {type: str}
+        allows_empty: True   
+#add filter extension  
             
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:

--- a/python/tk_multi_workfiles/save_as.py
+++ b/python/tk_multi_workfiles/save_as.py
@@ -140,9 +140,14 @@ class SaveAs(object):
         been done
         """
         # always try to create folders:
+        folder = os.path.dirname(new_path)
         ctx_entity = self._app.context.task or self._app.context.entity or self._app.context.project
         if ctx_entity:
             self._app.tank.create_filesystem_structure(ctx_entity.get("type"), ctx_entity.get("id"))
+            folders = self._app.tank.preview_filesystem_structure(ctx_entity.get("type"), ctx_entity.get("id"))
+            #this always takes long it is strange why it wont work in our config but this way the folders will get created
+        if folder not in folders:
+            self._app.ensure_folder_exists(folder)
         
         # and save the current file as the new path:
         save_file(self._app, SAVE_FILE_AS_ACTION, self._app.context, new_path)

--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -829,6 +829,13 @@ class WorkFiles(object):
             # make sure path matches publish template:            
             if not self._publish_template.validate(path):
                 continue
+
+#add filter extension"""                
+            self._file_extensions = self._app.get_setting("file_extensions", [])
+            if self._file_extensions:
+                if not path.split(".")[-1] in self._file_extensions:
+                    continue
+#end add filter extension"""
                 
             details = sg_file.copy()
             details["path"] = path


### PR DESCRIPTION
made the save as a bit more bullet proof..
As we had problems that files could not be saved that way...

Then we have a general schema with extensions as a key {ext}.
This way it can happen that the app gets an mp4 instead of a maya scene file out of the library.
The extension setting would prevent that.
And if it is empty it wont filter anything

I thought it might be easier for you to examine what we want instead of having discussions via email...
And you can reject what does not make sense easily...

Enjoy Siggraph

Johannes
