### PR TITLE
#24275 - Publishes with no local path are now ignored by the app.

### DIFF
--- a/python/tk_multi_workfiles/versioning.py
+++ b/python/tk_multi_workfiles/versioning.py
@@ -241,7 +241,12 @@ class Versioning(object):
         
         published_file_entity_type = tank.util.get_published_file_entity_type(self._app.tank)
         sg_result = self._app.shotgun.find(published_file_entity_type, filters, ["path", "version_number"])
-        paths_and_versions = [(r.get("path").get("local_path"), r.get("version_number")) for r in sg_result if r.get("path")]
+        
+        paths_and_versions = []
+        for res in sg_result:
+            path = res.get("path", {}).get("local_path")
+            if path:
+                paths_and_versions.append((path, res.get("version_number")))
  
         return paths_and_versions          
         

--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -1090,10 +1090,10 @@ class WorkFiles(object):
         
         publish_files = {}
         for sg_file in sg_published_files:
-            if not sg_file.get("path"):
-                continue
             
-            path = sg_file.get("path").get("local_path")
+            path = sg_file.get("path", {}).get("local_path")
+            if not path:
+                continue
             
             # check if this path should be ignored:
             if self._ignore_file_path(path):


### PR DESCRIPTION
This can happen if the local storage the path used is retired of if the
publish is not registered correctly.
