### PR TITLE
Added missing import for TankError

### DIFF
--- a/python/tk_multi_workfiles/find_files.py
+++ b/python/tk_multi_workfiles/find_files.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sgtk
+from tank import TankError
 
 def find_all_files(app, work_template, publish_template, context):
     """


### PR DESCRIPTION
TankError is used in the file but not imported.
This will trigger an error when for instance the folders for a task don't exist, so the context.as_template_fields() call fail and it tries to reach the except TankError part (line 97).
