### PR TITLE
Fixes #25466 - folders are no longer created as part of Shotgun Save-As.

### DIFF
--- a/python/tk_multi_workfiles/save_as.py
+++ b/python/tk_multi_workfiles/save_as.py
@@ -182,10 +182,10 @@ class SaveAs(object):
         # the Work area has been set without folder creation being run correctly.
         dir = os.path.dirname(new_path)
         if not dir or not os.path.exists(dir):
+            # work files always operates in some sort of context, either project, entity or task
             ctx_entity = self._app.context.task or self._app.context.entity or self._app.context.project
-            if ctx_entity:
-                self._app.log_debug("Creating folders for context %s" % self._app.context)
-                self._app.tank.create_filesystem_structure(ctx_entity.get("type"), ctx_entity.get("id"))
+            self._app.log_debug("Creating folders for context %s" % self._app.context)
+            self._app.tank.create_filesystem_structure(ctx_entity.get("type"), ctx_entity.get("id"))
         
         # and save the current file as the new path:
         save_file(self._app, SAVE_FILE_AS_ACTION, self._app.context, new_path)


### PR DESCRIPTION
Folder creation will still be run if the directory being saved to doesn't exist for some reason, for example if the Work Area has been changed without folders being created.
