### PR TITLE
fixed type issue in QMessageBox

### DIFF
--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -1051,7 +1051,7 @@ class WorkFiles(object):
             self._create_folders(self._context)
             self._restart_engine(self._context)
         except Exception, e:
-            QtGui.QMessageBox.critical(self,
+            QtGui.QMessageBox.critical(self._workfiles_ui,
                                        "Could not Change Work Area!",
                                        "Could not change work area and start a new "
                                        "engine. This may be because the task doesn't "


### PR DESCRIPTION
Invalid use of 'self' where self._workfiles_ui was needed, causing an exception while trying to indicate an error.
Effectively, the workspace wouldn't change, even though no error was obviously indicated. Instead, there was a call stack in the terminal.
