### PR TITLE
for #25173: manually emit kBeforeProjectLoad signal since Hiero doesn't

### DIFF
--- a/hooks/scene_operation_tk-hiero.py
+++ b/hooks/scene_operation_tk-hiero.py
@@ -62,6 +62,9 @@ class SceneOperation(Hook):
             return curr_path
 
         elif operation == "open":
+            # manually fire signal since Hiero doesn't fire this when loading 
+            # from the tk file manager
+            hiero.core.events.sendEvent("kBeforeProjectLoad", None)
             # open the specified script
             hiero.core.openProject(file_path.replace(os.path.sep, "/"))
         


### PR DESCRIPTION
Hiero has a bunch of signals it emits when certain actions take place. This includes a signal emitted both before and after a project is loaded. When loading through the Toolkit File Manager, Hiero doesn't emit the `kBeforeProjectLoad` signal (presumably because there's no way to know a project is about to be loaded when done this way?) 

This emits the signal manually immediately prior to the opening of the project. 
