### PR TITLE
for #25768: add missing os import causing last modified by info to barf

### DIFF
--- a/python/tk_multi_workfiles/users.py
+++ b/python/tk_multi_workfiles/users.py
@@ -11,6 +11,7 @@
 """
 Implementation of the user cache storing Shotgun user information
 """
+import os
 import sys
 
 class UserCache(object):


### PR DESCRIPTION
The "Updated By" information in the main window of the file manager was showing "Unknown" for all files. A missing import was causing that lookup to throw an exception which was being silently caught and passed. This adds the import back in so the lookup succeeds again.
