### PR TITLE
For #25787 - Display extra info for entities when selecting work area.

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -58,9 +58,10 @@ configuration:
 
     sg_entity_type_extra_display_fields:
       type: dict
-      description:  "Specify additional fields to display for each entity type in the task 
-                     browser.  For example, to display the name of the sequence that a shot 
-                     belongs to, specify: {'Shot':['sg_sequence.Sequence.code']}"
+      description:  "Specify additional fields to display for each entity type in the task browser. 
+                     Each entry in the dictionary maps an entity type to a dictionary of 'label:field'
+                     name pairs.  For example, to display the name of the sequence that a shot belongs 
+                     to, specify: {Shot:{Sequence: sg_sequence.Sequence.code}}"
       default_value: {}
            
     allow_task_creation:

--- a/python/tk_multi_workfiles/entity_browser.py
+++ b/python/tk_multi_workfiles/entity_browser.py
@@ -98,7 +98,7 @@ class EntityBrowserWidget(browser_widget.BrowserWidget):
                     filter.extend(entities_to_load[et])
                     entities = self._app.shotgun.find(et, 
                                                       [ filter ],
-                                                      query_fields + self.__entity_type_extra_fields.get(et, []),  
+                                                      query_fields + self.__entity_type_extra_fields.get(et, {}).values(),  
                                                       [{"field_name": "code", "direction": "asc"}])
                                         
                     # append to results:
@@ -116,7 +116,7 @@ class EntityBrowserWidget(browser_widget.BrowserWidget):
                 # get entities from shotgun:
                 entities = self._app.shotgun.find(et, 
                                                   sg_filters, 
-                                                  query_fields + self.__entity_type_extra_fields.get(et, []),
+                                                  query_fields + self.__entity_type_extra_fields.get(et, {}).values(),
                                                   [{"field_name": "code", "direction": "asc"}])
                                 
                 # append to results:
@@ -154,8 +154,11 @@ class EntityBrowserWidget(browser_widget.BrowserWidget):
                 details = "<b>%s %s</b>" % (tank.util.get_entity_type_display_name(self._app.tank, entity_type), 
                                             d.get("code"))
                 
-                # retrieve any extra info to display in the UI:
-                extra_info = ", ".join(str(d.get(f)) for f in self.__entity_type_extra_fields.get(entity_type, []))
+                # retrieve any extra info to display in the UI.  extra_fields is a dictionary of 'label:field'
+                # pairs for the current entity type.
+                extra_fields = self.__entity_type_extra_fields.get(entity_type, {})
+                extra_info = ", ".join(["%s: %s" % (label, str(d.get(field))) 
+                                        for label, field in extra_fields.iteritems()])
                 if extra_info:
                     details += "<br>(%s)" % extra_info
 

--- a/python/tk_multi_workfiles/work_files_form.py
+++ b/python/tk_multi_workfiles/work_files_form.py
@@ -327,15 +327,16 @@ class WorkFilesForm(QtGui.QWidget):
                 self._ui.entity_pages.setCurrentWidget(self._ui.entity_page)
                 self._ui.entity_pages.setVisible(True)
 
-                # get any extra fields that have been defined for this entity type:                
-                extra_fields = self._app.get_setting("sg_entity_type_extra_display_fields", {}).get(ctx.entity["type"], [])
+                # get any extra fields that have been defined for this entity type.  This will be a dictionary
+                # of label:field pairs for the current entity type:      
+                extra_fields = self._app.get_setting("sg_entity_type_extra_display_fields", {}).get(ctx.entity["type"], {})
                 
                 # get additional details:
                 sg_details = {}
                 try:
                     sg_details = self._app.shotgun.find_one(ctx.entity["type"], 
                                                             [["project", "is", ctx.project], ["id", "is", ctx.entity["id"]]], 
-                                                            ["description", "image", "code"] + extra_fields)
+                                                            ["description", "image", "code"] + extra_fields.values())
                 except:
                     pass
     
@@ -354,8 +355,9 @@ class WorkFilesForm(QtGui.QWidget):
                         entity_thumbnail = QtGui.QPixmap(thumbnail_path)
                 self._set_thumbnail(self._ui.entity_thumbnail, entity_thumbnail)
                                     
-                # description:
-                extra_info = ", ".join(str(sg_details.get(f)) for f in extra_fields)
+                # description including the display of extra fields:
+                extra_info = ", ".join(["%s: %s" % (label, str(sg_details.get(field))) 
+                                        for label, field in extra_fields.iteritems()])                
                 desc = ""
                 if extra_info:
                     desc += "(%s)<br>" % extra_info


### PR DESCRIPTION
Added ability to display extra information for entities in the select work area ui in a similar fashion to the existing functionality for tasks.

For example, you can now specify the following in the environment configuration:

```
sg_entity_type_extra_display_fields: {"Shot":["sg_sequence.Sequence.code"]}
```

which will then result in the Sequence name being shown below the Shot name for each shot when changing work area.  This information is also displayed in the current work area section of the main File manager UI.
