### PR TITLE
#26142 initial support for filtering Tasks in the selector widget

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -64,6 +64,18 @@ configuration:
                      to, specify: {Shot:{Sequence: sg_sequence.Sequence.code}}"
       default_value: {}
            
+    sg_task_filters:
+        type: list
+        description: "Allows you to filter the Tasks linked to the entities in the sg_entity_types 
+                      setting. Uses shotgun API query syntax. For example, if you only want to show 
+                      Tasks that are in progress in the task selector UI, you can set this up by 
+                      specifying a filter. Like this:
+                      sg_task_filters: [['sg_status_list', 'is', 'ip']]} "            
+        default_value: []
+        values:
+          type: shotgun_filter
+        allows_empty: True
+
     allow_task_creation:
         type: bool
         description: Controls whether new tasks can be created from the app.

--- a/python/tk_multi_workfiles/task_browser.py
+++ b/python/tk_multi_workfiles/task_browser.py
@@ -27,6 +27,8 @@ class TaskBrowserWidget(browser_widget.BrowserWidget):
         self._current_user = None
         self._current_user_loaded = False
         self._status_name_lookup = None
+        app = tank.platform.current_bundle()
+        self.__task_filters = app.get_setting("sg_task_filters", [])
         
     @property
     def selected_task(self):
@@ -101,10 +103,13 @@ class TaskBrowserWidget(browser_widget.BrowserWidget):
                                                     fields)
         else:
             # get all tasks
+            sg_filters = [ ["project", "is", self._app.context.project],
+                           ["step", "is_not", None],
+                           ["entity", "is", data["entity"] ] ]
+            sg_filters.extend( self.__task_filters )               
+            
             output["tasks"] = self._app.shotgun.find("Task", 
-                                                [ ["project", "is", self._app.context.project],
-                                                  ["step", "is_not", None],
-                                                  ["entity", "is", data["entity"] ] ], 
+                                                sg_filters, 
                                                 fields)
         
             # get all the users where tasks are assigned.


### PR DESCRIPTION
This adds the `sg_task_filters` setting which allows you to add additional filters to control which Tasks are displayed in the Task selector widget when selecting your file to open or changing your context. For example, this can be helpful if you want to only allow artists pick up work for Tasks that are 'ip'.

Note: This filter doesn't get applied in the following cases:
- when changing your context and you select the "Only Show My Tasks" checkbox (not sure if this is good or bad behavior)
- If you open Maya in the context of a Task that wouldn't otherwise match the filter, then you open the File Manager, the Task is already loaded and will therefore show files for the Task. If you switch contexts, you won't be able to switch back to the original Task however, because the filter won't match it when it queries Shotgun again.
