### PR TITLE
For 27137 - Set additional fields to ignore when comparing file versions

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -155,6 +155,20 @@ configuration:
         type: str
       allows_empty: True
       default_value: []
+      
+    version_compare_ignore_fields:
+      type: list
+      description:  A list of fields that should be ignored when comparing files to
+                    determine if they are different versions of the same file.  If 
+                    this is left empty then only the version field will be ignored.
+                    Care should be taken when specifying fields to ignore as Toolkit 
+                    will expect the version to be unique across files that have 
+                    different values for those fields and will error if this isn't the
+                    case.
+      values:
+        type: str
+      allows_empty: True
+      default_value: []
 
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:

--- a/python/tk_multi_workfiles/file_item.py
+++ b/python/tk_multi_workfiles/file_item.py
@@ -15,6 +15,40 @@ class FileItem(object):
     """
     Encapsulate details about a work file
     """
+    
+    @staticmethod
+    def build_file_key(fields, template, ignore_fields = None):
+        """
+        Build a unique key from the specified fields and template.  This will be
+        used to determine if multiple files are actually versions of the same
+        file.
+        
+        :param fields:          A dictionary of fields extracted from a file path
+        :param template:        The template that represents the files this key will be 
+                                used to compare.
+        :param ignore_fields:   A list of fields to ignore when constructing the key.
+                                Typically this will contain at least 'version' but it 
+                                may also contain other fields (e.g. user initials in
+                                the file name).
+        :returns:               An immutable 'key' that can be used for comparison and
+                                as the key in a dictionary (e.g. a string).
+        """
+        # default ignore keys to just 'version':
+        ignore_fields = ignore_fields or ["version"]
+
+        file_key = {}
+        template_keys = template.keys
+        for name, value in fields.iteritems():
+            if name not in template_keys:
+                continue
+            if name in ignore_fields:
+                continue
+            file_key[name] = value
+        
+        # return a string representation of the sorted dictionary:
+        # e.g. "[('name', 'foo'), ('sequence', 'Sequence01'), ('shot', 'shot_010')]"
+        return str(sorted(file_key.iteritems()))
+    
     def __init__(self, path, publish_path, is_local, is_published, details, key):
         """
         Construction
@@ -61,7 +95,7 @@ class FileItem(object):
 
     @property
     def key(self):
-        # a key that matches across all versions of a single file.
+        # a unique key that matches across all versions of a single file.
         return self._key
 
     """


### PR DESCRIPTION
This adds a configuration setting that can be used to specify additional fields to ignore in file paths when comparing them to find differing versions of the same file.  

For example, if the file name contains the user initials but all users should see these files as a continuous sequence of versions then this setting can be used to achieve this.
