### PR TITLE
33063 Add user activity metrics calls

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -185,9 +185,6 @@ requires_shotgun_version:
 requires_core_version: "v0.16.31"
 requires_engine_version:
 
-# XXX will require core that supports metrics logging
-
-
 # the engines that this app can operate in:
 supported_engines: 
 

--- a/info.yml
+++ b/info.yml
@@ -183,7 +183,10 @@ description: "Using this app you can change the current work area and
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.16.31"
-requires_engine_version: 
+requires_engine_version:
+
+# XXX will require core that supports metrics logging
+
 
 # the engines that this app can operate in:
 supported_engines: 

--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -462,7 +462,11 @@ class WorkFiles(object):
         ctx_entity = file.task or file.entity or self._context.project
         new_ctx = self._app.tank.context_from_entity(ctx_entity.get("type"), ctx_entity.get("id"))
 
-        self._app.log_metric("Open workfile")
+        try:
+            self._app.log_metric("Open workfile")
+        except:
+            # ignore all errors. ex: using a core that doesn't support metrics
+            pass
 
         return self._do_copy_and_open(src_path, work_path, None, not file.editable, new_ctx)
         
@@ -526,7 +530,11 @@ class WorkFiles(object):
         ctx_entity = file.task or file.entity or self._context.project
         new_ctx = self._app.tank.context_from_entity(ctx_entity.get("type"), ctx_entity.get("id"))
 
-        self._app.log_metric("Open published file")
+        try:
+            self._app.log_metric("Open published file")
+        except:
+            # ignore all errors. ex: using a core that doesn't support metrics
+            pass
 
         return self._do_copy_and_open(src_path, work_path, None, not file.editable, new_ctx)
         
@@ -711,7 +719,11 @@ class WorkFiles(object):
             self._app.log_exception("Failed to complete new file operation")
             return
         else:
-            self._app.log_metric("New file")
+            try:
+                self._app.log_metric("New file")
+            except:
+                # ignore all errors. ex: using a core that doesn't support metrics
+                pass
 
         # close work files UI:
         self._workfiles_ui.close()

--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -460,7 +460,9 @@ class WorkFiles(object):
                     
         # get best context we can for file:
         ctx_entity = file.task or file.entity or self._context.project
-        new_ctx = self._app.tank.context_from_entity(ctx_entity.get("type"), ctx_entity.get("id"))  
+        new_ctx = self._app.tank.context_from_entity(ctx_entity.get("type"), ctx_entity.get("id"))
+
+        self._app.log_metric("Open workfile")
 
         return self._do_copy_and_open(src_path, work_path, None, not file.editable, new_ctx)
         
@@ -523,7 +525,9 @@ class WorkFiles(object):
         # get best context we can for file:
         ctx_entity = file.task or file.entity or self._context.project
         new_ctx = self._app.tank.context_from_entity(ctx_entity.get("type"), ctx_entity.get("id"))
-        
+
+        self._app.log_metric("Open published file")
+
         return self._do_copy_and_open(src_path, work_path, None, not file.editable, new_ctx)
         
     def _do_open_publish_read_only(self, file, is_latest):
@@ -706,6 +710,8 @@ class WorkFiles(object):
                                        "Failed to complete new file operation:\n\n%s!" % e)
             self._app.log_exception("Failed to complete new file operation")
             return
+        else:
+            self._app.log_metric("New file")
 
         # close work files UI:
         self._workfiles_ui.close()


### PR DESCRIPTION
The calls log the metrics internally and ignore any errors. This prevents the need to force the app/fw users to update to a new core that supports metrics. When a supported core is updated, the metrics will be logged.