### PR TITLE
For #35267, can overwrite file when missing keys

### DIFF
--- a/python/tk_multi_workfiles/find_files.py
+++ b/python/tk_multi_workfiles/find_files.py
@@ -312,10 +312,9 @@ class FileFinder(object):
         except TankError:
             if require_path:
                 self.__app.log_exception("Unable to resolve all template fields.")
-                # and raise a new, clearer exception for this specific use case:
-                raise TankError("Unable to resolve template fields!  This could mean there is a mismatch "
-                                "between your folder schema and templates.  Please email "
-                                "support@shotgunsoftware.com if you need help fixing this.")
+                self.__app.log_debug("Template: %s" % work_template)
+                self.__app.log_debug("Context:  %s" % context)
+                raise
             # could not resolve fields from this context. This typically happens
             # when the context object does not have any corresponding objects on 
             # disk / in the path cache. In this case, we cannot continue with any

--- a/python/tk_multi_workfiles/find_files.py
+++ b/python/tk_multi_workfiles/find_files.py
@@ -49,6 +49,9 @@ class FileFinder(object):
         :param filter_file_key:     A unique file 'key' that if specified will limit the returned list of files to just 
                                     those that match.  This 'key' should be generated using the FileItem.build_file_key()
                                     method.
+        :param require_path:        If True, ensures that all fields of the template
+                                    can be resolved. Defaults to False.
+
         :returns:                   A list of FileItem instances, one for each unique version of a file found in either 
                                     the work or publish areas
         """
@@ -289,15 +292,18 @@ class FileFinder(object):
             
         return published_files
     
-        
     def __find_work_files(self, context, work_template, require_path):
         """
         Find all work files for the specified context and work template
-        
+
         :param context:             The context to find work files for
         :param publish_template:    The work template to match found files against
+        :param require_path:        If True, ensures that all fields of the template
+                                    can be resolved.
         :returns:                   List of dictionaries, each one containing the details
-                                    of an individual work file        
+                                    of an individual work file
+
+        :raises TankError: Raised when not all fields of the template can be resolved.
         """
         # find work files that match the current work template:
         work_fields = []

--- a/python/tk_multi_workfiles/save_as.py
+++ b/python/tk_multi_workfiles/save_as.py
@@ -160,7 +160,13 @@ class SaveAs(object):
                     name = form.name
                     reset_version = form.reset_version
                     
-                    details = self.generate_new_work_file_path(current_path, is_publish, name, reset_version)
+                    try:
+                        details = self.generate_new_work_file_path(current_path, is_publish, name, reset_version, require_path=True)
+                    except TankError, e:
+                        QtGui.QMessageBox.critical(None, "Failed to save file!", "Failed to save file:\n\n%s" % str(e))
+                        self._app.log_exception("Something went wrong while saving!")
+                        continue
+
                     new_path = details.get("path")
                     msg = details.get("message")
                     
@@ -207,7 +213,7 @@ class SaveAs(object):
         # and save the current file as the new path:
         save_file(self._app, SAVE_FILE_AS_ACTION, self._app.context, new_path)
         
-    def generate_new_work_file_path(self, current_path, current_is_publish, new_name, reset_version):
+    def generate_new_work_file_path(self, current_path, current_is_publish, new_name, reset_version, require_path=False):
         """
         Generate a new work file path from the current path taking into
         account existing work files and publishes.
@@ -259,7 +265,7 @@ class SaveAs(object):
         # if we haven't cached the file list already, do it now:
         if not self._cached_files:
             finder = FileFinder(self._app)
-            self._cached_files = finder.find_files(self._work_template, self._publish_template, self._app.context)
+            self._cached_files = finder.find_files(self._work_template, self._publish_template, self._app.context, require_path=require_path)
 
         # construct a file key that represents all versions of this publish/work file:
         file_key = FileItem.build_file_key(fields, self._work_template, 


### PR DESCRIPTION
Replicated the logic of the workfiles 2 app to prevent saving when not all keys can be validated.